### PR TITLE
Toast position support (top/bottom-left/right)

### DIFF
--- a/components/Toast.vue
+++ b/components/Toast.vue
@@ -8,7 +8,8 @@
     leave-to-class="opacity-0"
   >
     <div
-      class="fixed inset-0 flex items-end justify-center px-4 py-6 pointer-events-none sm:p-6 sm:items-start sm:justify-end z-10"
+      :class="[positionClass]"
+      class="fixed inset-0 flex items-end justify-center px-4 py-6 pointer-events-none sm:p-8 z-10"
       v-show="show"
     >
       <div
@@ -78,6 +79,10 @@ export default {
     },
     toastClass: {
       type: String,
+    },
+    positionClass: {
+      type: String,
+      default: 'sm:items-start sm:justify-end'
     }
   },
   data() {


### PR DESCRIPTION
Support for choosing toast message position on **sm+** devices. Mobile stays the same.

Additional positionClass prop, default is `sm:items-start sm:justify-end` (top-right)

Other options:

- `sm:items-start sm:justify-start` (top-left)
- `sm:items-end sm:justify-start` (bottom-left)
- `sm:items-end sm:justify-end` (bottom-right)

Or anything custom, of course.