### PR TITLE
CustomSelect correct border + error color

### DIFF
--- a/components/Input/CustomSelect.vue
+++ b/components/Input/CustomSelect.vue
@@ -6,8 +6,8 @@
       aria-haspopup="listbox"
       aria-expanded="true"
       aria-labelledby="listbox-label"
-      class="bg-white relative w-full border border-gray-300 rounded-md shadow-sm pl-3 pr-10 py-2 text-left cursor-default focus:outline-none text-sm"
-      :class="[buttonClass]"
+      class="bg-white relative w-full border rounded-md shadow-sm pl-3 pr-10 py-2 text-left cursor-default focus:outline-none text-sm"
+      :class="[buttonClass] + (errors.length > 0 ? ' border-red-300' : ' border-gray-300')"
     >
       <slot
         name="selectedLabel"
@@ -225,7 +225,7 @@ export default {
     },
     buttonClass: {
       type: String,
-      default: "focus:ring-1 focus:ring-gray-500 focus:border-gray-500",
+      default: "focus:ring-1 focus:ring-red-500 focus:border-red-500",
     },
     labelResolver: {
       default: null,


### PR DESCRIPTION
- Added the error border color to custom select element (border-red-300)

Default values changed to match other elements:
- Changed default border to **border-gray-300**
- Changed focus border and ring to **border-red-500 / ring-red-500**